### PR TITLE
Update for new IBM Cloud `Databases for PostgreSQL`

### DIFF
--- a/notebooks/WatsonOpenScaleSageMakerMLengine.ipynb
+++ b/notebooks/WatsonOpenScaleSageMakerMLengine.ipynb
@@ -66,12 +66,35 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> NOTE: Below cell is a temporary fix as of 2/25/2019. Remove it and this comment, and un-comment regular `pip install ibm-ai-openscale==2.2.0.29` when that becomes valid."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install ibm-ai-openscale==1.0.429 --no-cache | tail -n 1"
+    "!pip install -i https://test.pypi.org/simple/ ibm-ai-openscale==2.1.0.29"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> NOTE: ibm-ai-openscale is not on PyPi as of 2/25/2019. When it is, uncomment below and run that instead of cell above"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#!pip install ibm-ai-openscale==2.1.0.29 --no-cache | tail -n 1"
    ]
   },
   {
@@ -158,21 +181,62 @@
    "outputs": [],
    "source": [
     "POSTGRES_CREDENTIALS = {\n",
-    "  \"db_type\": \"postgresql\",\n",
-    "  \"uri_cli_1\": \"****\",\n",
-    "  \"maps\": [],\n",
-    "  \"instance_administration_api\": {\n",
-    "    \"instance_id\": \"****\",\n",
-    "    \"root\": \"****\",\n",
-    "    \"deployment_id\": \"****\"\n",
+    "  \"connection\": {\n",
+    "    \"cli\": {\n",
+    "      \"arguments\": [\n",
+    "        [\n",
+    "          \"host=****.databases.appdomain.cloud port=31173 dbname=ibmclouddb user=**** sslmode=verify-full\"\n",
+    "        ]\n",
+    "      ],\n",
+    "      \"bin\": \"psql\",\n",
+    "      \"certificate\": {\n",
+    "        \"certificate_base64\": \"****\",\n",
+    "        \"name\": \"****\"\n",
+    "      },\n",
+    "      \"composed\": [\n",
+    "        \"PGPASSWORD=**** PGSSLROOTCERT=**** psql 'host=****.databases.appdomain.cloud port=31173 dbname=ibmclouddb user=ibm_cloud_*** sslmode=verify-full'\"\n",
+    "      ],\n",
+    "      \"environment\": {\n",
+    "        \"PGPASSWORD\": \"****\",\n",
+    "        \"PGSSLROOTCERT\": \"****\"\n",
+    "      },\n",
+    "      \"type\": \"cli\"\n",
+    "    },\n",
+    "    \"postgres\": {\n",
+    "      \"authentication\": {\n",
+    "        \"method\": \"direct\",\n",
+    "        \"password\": \"****\",\n",
+    "        \"username\": \"ibm_cloud_****\"\n",
+    "      },\n",
+    "      \"certificate\": {\n",
+    "        \"certificate_base64\": \"****\",\n",
+    "        \"name\": \"****\"\n",
+    "      },\n",
+    "      \"composed\": [\n",
+    "        \"postgres://ibm_cloud_***:***.****.databases.appdomain.cloud:31173/ibmclouddb?sslmode=verify-full\"\n",
+    "      ],\n",
+    "      \"database\": \"ibmclouddb\",\n",
+    "      \"hosts\": [\n",
+    "        {\n",
+    "          \"hostname\": \"****.databases.appdomain.cloud\",\n",
+    "          \"port\": 31173,\n",
+    "          \"protocol\": \"postgres\"\n",
+    "        }\n",
+    "      ],\n",
+    "      \"path\": \"/ibmclouddb\",\n",
+    "      \"query_options\": {\n",
+    "        \"sslmode\": \"verify-full\"\n",
+    "      },\n",
+    "      \"scheme\": \"postgres\",\n",
+    "      \"type\": \"uri\"\n",
+    "    }\n",
     "  },\n",
-    "  \"name\": \"****\",\n",
-    "  \"uri_cli\": \"****\",\n",
-    "  \"uri_direct_1\": \"****\",\n",
-    "  \"ca_certificate_base64\": ****\",\n",
-    "  \"deployment_id\": \"****\",\n",
-    "  \"uri\": \"****\"\n",
-    "}\n"
+    "  \"instance_administration_api\": {\n",
+    "    \"deployment_id\": \"crn:v1:bluemix:public:databases-for-postgresql:us-south:a/****::\",\n",
+    "    \"instance_id\": \"crn:v1:bluemix:public:databases-for-postgresql:us-south:a/****::\",\n",
+    "    \"root\": \"https://api.******.databases.cloud.ibm.com/v4/ibm\"\n",
+    "  }\n",
+    "}"
    ]
   },
   {
@@ -219,19 +283,26 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "client.data_mart.delete()"
+    "### 1.2 DataMart setup"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 1.2 DataMart setup"
+    ">NOTE: If you have already created a data_mart and need to delete it, uncomment and run the cell below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#client.data_mart.delete()"
    ]
   },
   {


### PR DESCRIPTION
> NOTE: The notebook currently points to:
`https://test.pypi.org/simple/` instead of production
PyPi. When the upstream ibm-ai-openscale fix is on PyPi, this
will need to be changed. See comments in Notebook and Issue #17

Update for new credential structure of IBM Cloud
`Databases for PostgreSQL`.
Add `label_column` to `client.data_mart.subscriptions.add()` for
V 2.x breaking change.

Closes: #13
Closes: #14