### PR TITLE
Add sparse .travis.yml to make CI pass.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: generic
+script: false


### PR DESCRIPTION
Adding a minimal `.travis.yml` file to insure that
there are no false negatives in the case where someone
mistakenly turns on TravisCI for this repo.